### PR TITLE
0.6.0: at.REF always include default bits

### DIFF
--- a/pyardrone/__init__.py
+++ b/pyardrone/__init__.py
@@ -102,13 +102,19 @@ class HelperMixin:
         '''
         Sends the takeoff command.
         '''
-        self.send(at.REF(at.REF.input.default | at.REF.input.start))
+        self.send(at.REF(at.REF.input.start))
 
     def land(self):
         '''
         Sends the land command.
         '''
-        self.send(at.REF(at.REF.input.default))
+        self.send(at.REF())
+
+    def emergency(self):
+        '''
+        Sends the emergency command.
+        '''
+        self.send(at.REF(at.REF.input.select))
 
     def _move(self, roll=0, pitch=0, gaz=0, yaw=0):
         '''

--- a/pyardrone/__init__.py
+++ b/pyardrone/__init__.py
@@ -19,7 +19,7 @@ else:
     VIDEO = True
 
 
-__version__ = '0.5.1dev1'
+__version__ = '0.6.0'
 
 __all__ = ('ARDrone',)
 

--- a/pyardrone/at/__init__.py
+++ b/pyardrone/at/__init__.py
@@ -16,11 +16,9 @@ __all__ = (
 )
 
 
-class REF(ATCommand):
-
+class REF_0_5(ATCommand):
     '''
-    Controls the basic behaviour of the drone (take-off/landing, emergency
-    stop/reset)
+    at.REF interface of version 0.5
     '''
 
     input = parameters.Int32(
@@ -32,6 +30,21 @@ class REF(ATCommand):
         start=bits(9),  # Takeoff / Land
         select=bits(8),  # Switch of emergency mode
     )
+
+
+class REF(REF_0_5):
+    '''
+    Controls the basic behaviour of the drone (take-off/landing, emergency
+    stop/reset)
+    '''
+
+    def __new__(cls, input, *, use_default_bits=True):
+        if int.bit_length(input) > 32:
+            raise ValueError(
+                'value input {} should be less than 4 bytes'.format(input))
+        if use_default_bits:
+            input |= cls.input.default
+        return super().__new__(cls, input)
 
 
 class PCMD(ATCommand):

--- a/pyardrone/at/__init__.py
+++ b/pyardrone/at/__init__.py
@@ -38,7 +38,7 @@ class REF(REF_0_5):
     stop/reset)
     '''
 
-    def __new__(cls, input, *, use_default_bits=True):
+    def __new__(cls, input=0, *, use_default_bits=True):
         if int.bit_length(input) > 32:
             raise ValueError(
                 'value input {} should be less than 4 bytes'.format(input))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='pyardrone',
-    version='0.5.1dev1',
+    version='0.6.0',
     packages=['pyardrone', 'pyardrone.at', 'pyardrone.navdata', 'pyardrone.utils'],
     include_package_data=True,
     license='MIT License',

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -8,53 +8,53 @@ from pyardrone.utils import repack_to_int
 class CommandTest(unittest.TestCase):
 
     def test_init_by_arg(self):
-        cmd = at.REF(3)
+        cmd = at.REF_0_5(3)
         self.assertEqual(cmd.input, 3)
 
     def test_init_by_kwarg(self):
-        cmd = at.REF(input=3)
+        cmd = at.REF_0_5(input=3)
         self.assertEqual(cmd.input, 3)
 
     def test_too_many_arguments_raises_TypeError(self):
         with self.assertRaises(TypeError):
-            at.REF(3, 7)
+            at.REF_0_5(3, 7)
 
     def test_duplicate_value_raises_TypeError(self):
         with self.assertRaises(TypeError):
-            at.REF(3, input=7)
+            at.REF_0_5(3, input=7)
 
     def test_wrong_type_raises_TypeError(self):
         with self.assertRaises(TypeError):
-            at.REF(0.5)
+            at.REF_0_5(0.5)
 
     def test_repr(self):
-        self.assertEqual(repr(at.REF(3)), 'REF(input=3)')
+        self.assertEqual(repr(at.REF_0_5(3)), 'REF_0_5(input=3)')
 
     def test_equal(self):
-        self.assertEqual(at.REF(20), at.REF(20))
+        self.assertEqual(at.REF_0_5(20), at.REF_0_5(20))
 
     def test_unequal_different_argument(self):
-        self.assertNotEqual(at.REF(10), at.REF(12))
+        self.assertNotEqual(at.REF_0_5(10), at.REF_0_5(12))
 
     def test_different_commands_with_same_arguments_are_different(self):
-        class REF2(base.ATCommand):
+        class REF_0_52(base.ATCommand):
 
             input = parameters.Int32()
 
-        self.assertNotEqual(at.REF(3), REF2(3))
+        self.assertNotEqual(at.REF_0_5(3), REF_0_52(3))
 
     def test_not_equal_to_other_type(self):
-        self.assertNotEqual(at.REF(17), 17)
+        self.assertNotEqual(at.REF_0_5(17), 17)
 
     def test_pack(self):
-        self.assertEqual(at.REF(20)._pack(100), b'AT*REF=100,20\r')
+        self.assertEqual(at.REF_0_5(20)._pack(100), b'AT*REF_0_5=100,20\r')
 
     def test_command_arguments_can_not_be_assigned(self):
         with self.assertRaises(AttributeError):
-            at.REF(10).input = 11
+            at.REF_0_5(10).input = 11
 
     def test_attributes_which_are_not_arguments_can_be_assigned(self):
-        at.REF(11).some_attribute = 20
+        at.REF_0_5(11).some_attribute = 20
 
     def test_parameterless_pack_does_not_end_with_comma(self):
         self.assertEqual(
@@ -202,6 +202,15 @@ class ConstantTest(unittest.TestCase):
         ...with a mode parameter equaling 4 (CFG_GET_CONTROL_MODE)
         '''
         self.assertEqual(at.CTRL.mode.CFG_GET_CONTROL_MODE, 4)
+
+
+class AtREFDefaults(unittest.TestCase):
+
+    def test_defaults_are_added(self):
+        self.assertEqual(at.REF(60).input, 60 | at.REF.input.default)
+
+    def test_defaults_can_be_disabled(self):
+        self.assertEqual(at.REF(60, use_default_bits=False).input, 60)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#14 